### PR TITLE
Priority system and some rewrites

### DIFF
--- a/ReviveAPI.cs
+++ b/ReviveAPI.cs
@@ -104,13 +104,6 @@ namespace ReviveAPI
             IL.RoR2.CharacterMaster.IsDeadAndOutOfLivesServer += CharacterMaster_IsDeadAndOutOfLivesServer;
             IL.RoR2.CharacterMaster.OnBodyDeath += CharacterMaster_OnBodyDeath;
             hooksSet = true;
-
-            IL.RoR2.CharacterMaster.OnBodyDeath += TestHookToSeeChanges;
-        }
-
-        private void TestHookToSeeChanges(ILContext il)
-        {
-            Logger.LogInfo(il);
         }
 
         private void UnsetHooks()

--- a/ReviveAPI.cs
+++ b/ReviveAPI.cs
@@ -115,8 +115,10 @@ namespace ReviveAPI
             IL.RoR2.Artifacts.DoppelgangerInvasionManager.OnCharacterDeathGlobal += DoppelgangerInvasionManager_OnCharacterDeathGlobal;
             IL.RoR2.CharacterMaster.IsDeadAndOutOfLivesServer += CharacterMaster_IsDeadAndOutOfLivesServer;
             IL.RoR2.CharacterMaster.OnBodyDeath += CharacterMaster_OnBodyDeath;
+            On.RoR2.CharacterMaster.IsExtraLifePendingServer += CharacterMaster_IsExtraLifePendingServer;
             hooksSet = true;
         }
+
 
         private void UnsetHooks()
         {
@@ -125,7 +127,18 @@ namespace ReviveAPI
             IL.RoR2.Artifacts.DoppelgangerInvasionManager.OnCharacterDeathGlobal -= DoppelgangerInvasionManager_OnCharacterDeathGlobal;
             IL.RoR2.CharacterMaster.IsDeadAndOutOfLivesServer -= CharacterMaster_IsDeadAndOutOfLivesServer;
             IL.RoR2.CharacterMaster.OnBodyDeath -= CharacterMaster_OnBodyDeath;
+            On.RoR2.CharacterMaster.IsExtraLifePendingServer -= CharacterMaster_IsExtraLifePendingServer;
             hooksSet = false;
+        }
+
+        private bool CharacterMaster_IsExtraLifePendingServer(On.RoR2.CharacterMaster.orig_IsExtraLifePendingServer orig, CharacterMaster self)
+        {
+            var result = orig(self);
+            if (!result)
+            {
+                result = pendingRevives.Where(x => x.characterMaster == self).ToArray().Length > 0;
+            }
+            return result;
         }
 
         private void TeamDeathArtifactManager_OnServerCharacterDeathGlobal(ILContext iLContext)

--- a/ReviveAPI.csproj
+++ b/ReviveAPI.csproj
@@ -8,14 +8,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="BepInEx.Core" Version="5.4.21" />
-		<PackageReference Include="R2API.Addressables" Version="1.0.4" />
-		<PackageReference Include="R2API.ProcType" Version="1.0.2" />
-		<PackageReference Include="R2API.CharacterBody" Version="1.0.0" />
 		<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.9-r.0" />
 		<PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
 		<PackageReference Include="MMHOOK.RoR2" Version="2025.6.3" />
-		<PackageReference Include="R2API" Version="5.0.5" />
-		<PackageReference Include="Rune580.Mods.RiskOfRain2.RiskOfOptions" Version="2.8.2" />
 	</ItemGroup>
 
 </Project>

--- a/Tests.cs
+++ b/Tests.cs
@@ -1,0 +1,199 @@
+﻿using RoR2;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace ReviveAPI
+{
+    public class Tests
+    {
+        public static void AddRevives()
+        {
+            ReviveAPI.AddCustomRevive(CanReviveSyringe, new ReviveAPI.PendingOnRevive[]
+                {
+                    new ReviveAPI.PendingOnRevive
+                    {
+                        onReviveDelegate = ReviveWithEffectsSyringe,
+                        timer = 2f,
+                    }
+                },
+                33);
+
+            ReviveAPI.AddCustomRevive(CanReviveMedkit, new ReviveAPI.PendingOnRevive[]
+                {
+                    new ReviveAPI.PendingOnRevive
+                    {
+                        onReviveDelegate = ReviveWithEffectsMedkit,
+                        timer = 2f,
+                    }
+                },
+                44);
+            ReviveAPI.AddCustomRevive(CanReviveGlasses, new ReviveAPI.PendingOnRevive[]
+                {
+                    new ReviveAPI.PendingOnRevive
+                    {
+                        onReviveDelegate = ReviveWithEffectsGlasses,
+                        timer = 2f,
+                    }
+                },
+                -44);
+            ReviveAPI.AddCustomRevive(CanReviveHoof, new ReviveAPI.PendingOnRevive[]
+                {
+                    new ReviveAPI.PendingOnRevive
+                    {
+                        onReviveDelegate = ReviveWithEffectsHoof,
+                        timer = 2f,
+                    }
+                },
+                -10);
+        }
+
+        #region LowPriorityBeforeVanilla(Syringe)
+        private static void ReviveWithEffectsSyringe(CharacterMaster master)
+        {
+            ReviveAPI.ManualLogger.LogInfo($"Revivng {master} via Syringe.");
+            var vector = master.deathFootPosition;
+            master.Respawn(master.deathFootPosition, Quaternion.Euler(0f, UnityEngine.Random.Range(0f, 360f), 0f), true);
+            var body = master.GetBody();
+            body.AddTimedBuff(RoR2Content.Buffs.Immune, 3f);
+            master.inventory.RemoveItem(RoR2Content.Items.Syringe, master.inventory.GetItemCount(RoR2Content.Items.Syringe));
+            if (master.bodyInstanceObject)
+            {
+                EntityStateMachine[] components = master.bodyInstanceObject.GetComponents<EntityStateMachine>();
+                foreach (EntityStateMachine obj in components)
+                {
+                    obj.initialStateType = obj.mainStateType;
+                }
+                if (master.gameObject)
+                {
+                    var effect = Addressables.LoadAssetAsync<GameObject>(RoR2BepInExPack.GameAssetPaths.RoR2_DLC1_VoidSurvivor.VoidSurvivorCorruptDeathMuzzleflash_prefab).WaitForCompletion();
+                    if (effect)
+                    {
+                        EffectManager.SpawnEffect(effect, new EffectData
+                        {
+                            origin = vector,
+                            rotation = master.bodyInstanceObject.transform.rotation
+                        }, transmit: true);
+                    }
+                }
+            }
+        }
+
+        private static bool CanReviveSyringe(CharacterMaster master)
+        {
+            return master.inventory.GetItemCount(RoR2Content.Items.Syringe) > 0;
+        }
+        #endregion
+
+        #region HighPriorityBeforeVanilla(Medkit)
+        private static void ReviveWithEffectsMedkit(CharacterMaster master)
+        {
+            ReviveAPI.ManualLogger.LogInfo($"Revivng {master} via MedKit.");
+            var vector = master.deathFootPosition;
+            master.Respawn(master.deathFootPosition, Quaternion.Euler(0f, UnityEngine.Random.Range(0f, 360f), 0f), true);
+            var body = master.GetBody();
+            body.AddTimedBuff(RoR2Content.Buffs.Immune, 3f);
+            master.inventory.RemoveItem(RoR2Content.Items.Medkit, master.inventory.GetItemCount(RoR2Content.Items.Medkit));
+            if (master.bodyInstanceObject)
+            {
+                EntityStateMachine[] components = master.bodyInstanceObject.GetComponents<EntityStateMachine>();
+                foreach (EntityStateMachine obj in components)
+                {
+                    obj.initialStateType = obj.mainStateType;
+                }
+                if (master.gameObject)
+                {
+                    var effect = Addressables.LoadAssetAsync<GameObject>(RoR2BepInExPack.GameAssetPaths.RoR2_Base_Common_VFX.BrittleDeath_prefab).WaitForCompletion();
+                    if (effect)
+                    {
+                        EffectManager.SpawnEffect(effect, new EffectData
+                        {
+                            origin = vector,
+                            rotation = master.bodyInstanceObject.transform.rotation
+                        }, transmit: true);
+                    }
+                }
+            }
+        }
+
+        private static bool CanReviveMedkit(CharacterMaster master)
+        {
+            return master.inventory.GetItemCount(RoR2Content.Items.Medkit) > 0;
+        }
+        #endregion
+
+        #region LowPriorityAfterVanilla(Glasses)
+        private static void ReviveWithEffectsGlasses(CharacterMaster master)
+        {
+            ReviveAPI.ManualLogger.LogInfo($"Revivng {master} via CritGlasses.");
+            var vector = master.deathFootPosition;
+            master.Respawn(master.deathFootPosition, Quaternion.Euler(0f, UnityEngine.Random.Range(0f, 360f), 0f), true);
+            var body = master.GetBody();
+            body.AddTimedBuff(RoR2Content.Buffs.Immune, 3f);
+            master.inventory.RemoveItem(RoR2Content.Items.CritGlasses, master.inventory.GetItemCount(RoR2Content.Items.CritGlasses));
+            if (master.bodyInstanceObject)
+            {
+                EntityStateMachine[] components = master.bodyInstanceObject.GetComponents<EntityStateMachine>();
+                foreach (EntityStateMachine obj in components)
+                {
+                    obj.initialStateType = obj.mainStateType;
+                }
+                if (master.gameObject)
+                {
+                    var effect = Addressables.LoadAssetAsync<GameObject>(RoR2BepInExPack.GameAssetPaths.RoR2_Base_Bandit2.Bandit2SmokeBomb_prefab).WaitForCompletion();
+                    if (effect)
+                    {
+                        EffectManager.SpawnEffect(effect, new EffectData
+                        {
+                            origin = vector,
+                            rotation = master.bodyInstanceObject.transform.rotation
+                        }, transmit: true);
+                    }
+                }
+            }
+        }
+
+        private static bool CanReviveGlasses(CharacterMaster master)
+        {
+            return master.inventory.GetItemCount(RoR2Content.Items.CritGlasses) > 0;
+        }
+        #endregion
+
+        #region HighPriorityAfterVanilla(Hoof)
+        private static void ReviveWithEffectsHoof(CharacterMaster master)
+        {
+            ReviveAPI.ManualLogger.LogInfo($"Revivng {master} via Hoof.");
+            var vector = master.deathFootPosition;
+            master.Respawn(master.deathFootPosition, Quaternion.Euler(0f, UnityEngine.Random.Range(0f, 360f), 0f), true);
+            var body = master.GetBody();
+            body.AddTimedBuff(RoR2Content.Buffs.Immune, 3f);
+            master.inventory.RemoveItem(RoR2Content.Items.Hoof, master.inventory.GetItemCount(RoR2Content.Items.Hoof));
+            if (master.bodyInstanceObject)
+            {
+                EntityStateMachine[] components = master.bodyInstanceObject.GetComponents<EntityStateMachine>();
+                foreach (EntityStateMachine obj in components)
+                {
+                    obj.initialStateType = obj.mainStateType;
+                }
+                if (master.gameObject)
+                {
+                    var effect = Addressables.LoadAssetAsync<GameObject>(RoR2BepInExPack.GameAssetPaths.RoR2_Base_Captain.CaptainTazerNova_prefab).WaitForCompletion();
+                    if (effect)
+                    {
+                        EffectManager.SpawnEffect(effect, new EffectData
+                        {
+                            origin = vector,
+                            rotation = master.bodyInstanceObject.transform.rotation
+                        }, transmit: true);
+                    }
+                }
+            }
+        }
+
+        private static bool CanReviveHoof(CharacterMaster master)
+        {
+            return master.inventory.GetItemCount(RoR2Content.Items.Hoof) > 0;
+        }
+        #endregion
+
+    }
+}


### PR DESCRIPTION
* Added priority system. You can specify `int priority` when adding revives, positive values happen before vanilla, negative and 0 happen after vanilla. Old methods are left in tact to not have binary breaking change (I haven't actually checked if Artifact of Eternity still works but it should), those add revives after vanilla, how it worked prior to this.
* Rewrote basically all hooks, separated checks and revive methods for those hooks, since checking via the same method as revives and actually calling those revives in places where only checks should happen was questionable at best.
* Added `IsExtraLifePendingServer` On hook, it is used by Scavs, used by `CombatSquad` to determine whether monster in combat squad is actually dead or not, etc. It is done by just getting `pendingRevives` for given `CharacterMaster` and if they exist then revive is pending.
* Added tests, basically Syringe, Hoof, CritGlasses and Medkit all give revives with different priorities. Controlled by a constant in main plugin class.
* There are still things that need to be addressed, but most likely are impossible with current system
  * `TrueKill` is not handled, but that's mostly because `TrueKill` just removes all vanilla items and invokes that lead to revive, we don't really have a way to do anything like this due to fact that `TrueKill` is the result of death, not other way around, so we can't just clear `pendingRevives` for given `CharacterMaster`. We can maybe add another delegate for `TrueKill` handling but that this point I feel like there is simply too many delegates.
